### PR TITLE
Item texture, tooltip and use functionality added

### DIFF
--- a/Templates.xml
+++ b/Templates.xml
@@ -36,6 +36,8 @@
                 GameTooltip_SetDefaultAnchor(GameTooltip, this)
                 if this.flyoutActionType == 0 then
                     GameTooltip:SetSpell(this.flyoutAction, 'spell')
+                elseif this.flyoutActionType == 2 then
+                    GameTooltip:SetBagItem(GetBagPosition(this.flyoutAction))
                 elseif this.flyoutActionType == 1 then
                     GameTooltip:SetText(GetMacroInfo(this.flyoutAction), 1, 1, 1)
                 end

--- a/main.lua
+++ b/main.lua
@@ -77,6 +77,56 @@ local function strsplit(str, delimiter, fillTable)
    return fillTable
 end
 
+-- ITEMS
+-- this can all be written better, but I don't care
+function GetBagPosition(name)
+  for bag = 0,4 do
+    for slot = 1,GetContainerNumSlots(bag) do
+      local item = GetContainerItemLink(bag,slot)
+      if item and string.find(strlower(item),strlower(name)) then
+        return bag, slot
+      end
+    end
+  end
+end
+
+function GetItemTexture(name)
+  for bag = 0,4 do
+    for slot = 1,GetContainerNumSlots(bag) do
+      local item = GetContainerItemLink(bag,slot)
+      if item and string.find(strlower(item),strlower(name)) then
+         local texture, _, _, _, _ = GetContainerItemInfo(bag,slot);
+        return texture
+      end
+    end
+  end
+end
+
+function GetBagItemByName(name)
+  for bag = 0,4 do
+    for slot = 1,GetContainerNumSlots(bag) do
+      local item = GetContainerItemLink(bag,slot)
+      if item and string.find(strlower(item),strlower(name)) then
+         local _,_,itemLink = string.find(GetContainerItemLink(bag,slot),"(item:%d+)")
+        return itemLink
+      end
+    end
+  end
+end
+
+function UseContainerItemByName(search)
+  for bag = 0,4 do
+    for slot = 1,GetContainerNumSlots(bag) do
+      local item = GetContainerItemLink(bag,slot)
+      if item and string.find(strlower(item),strlower(search)) then
+        UseContainerItem(bag,slot)
+      end
+    end
+  end
+end
+-- ITEMS
+
+
 -- credit: https://github.com/DanielAdolfsson/CleverMacro
 local function GetSpellSlotByName(name)
    name = strlower(name)
@@ -99,6 +149,8 @@ end
 local function GetFlyoutActionInfo(action)
    if GetSpellSlotByName(action) then
       return GetSpellSlotByName(action), 0
+   elseif GetBagItemByName(action) then
+      return GetBagItemByName(action), 2
    elseif GetMacroIndexByName(action) then
       return GetMacroIndexByName(action), 1
    end
@@ -243,6 +295,8 @@ function Flyout_OnClick(button)
          CastSpell(button.flyoutAction, 'spell')
       elseif button.flyoutActionType == 1 then
          Flyout_ExecuteMacro(button.flyoutAction)
+      elseif button.flyoutActionType == 2 then
+         UseContainerItem(GetBagPosition(button.flyoutAction))
       end
 
       Flyout_Hide(true)
@@ -381,6 +435,8 @@ function Flyout_Show(button)
          texture = GetSpellTexture(b.flyoutAction, 'spell')
       elseif b.flyoutActionType == 1 then
          _, texture = GetMacroInfo(b.flyoutAction)
+      elseif b.flyoutActionType == 2 then
+         texture = GetItemTexture(b.flyoutAction)
       end
 
       if texture then


### PR DESCRIPTION
Used the same as spells and macros, example:
/flyout Siamese;Elixir of Wisdom;Hearthstone;target;Heavy Leather Ball
<img width="198" height="55" alt="image" src="https://github.com/user-attachments/assets/8820dcba-0171-4d5d-901a-a990aef55d2d" />


Doesn't show item count, but also doesn't show an item if not in inventory.