### PR TITLE
Fixed default action not working with pfUI

### DIFF
--- a/compat.lua
+++ b/compat.lua
@@ -3,47 +3,34 @@ local _G = getfenv(0)
 -- upvalues
 local IsAddOnLoaded = IsAddOnLoaded
 
-local mod = math.mod
-
 -- Bongos
 local function GetActionButton_Bongos(action)
     return _G['BActionButton' .. action]
 end
 
 -- pfUI
+local PF_BARS = {
+    { name = "pfActionBarMain",       first = 1 },
+    { name = "pfActionBarPaging",     first = 13 },
+    { name = "pfActionBarRight",      first = 25 },
+    { name = "pfActionBarVertical",   first = 37 },
+    { name = "pfActionBarLeft",       first = 49 },
+    { name = "pfActionBarTop",        first = 61 },
+    { name = "pfActionBarStanceBar1", first = 73 },
+    { name = "pfActionBarStanceBar2", first = 85 },
+    { name = "pfActionBarStanceBar3", first = 97 },
+    { name = "pfActionBarStanceBar4", first = 109 },
+}
+
 local function GetActionButton_PF(action)
-    local bar = nil
-
-    if action < 25 then
-        bar = 'pfActionBarMain'
-    elseif action < 37 then
-        bar = 'pfActionBarRight'
-    elseif action < 49 then
-        bar = 'pfActionBarVertical'
-    elseif action < 61 then
-        bar = 'pfActionBarLeft'
-    elseif action < 73 then
-        bar = 'pfActionBarTop'
-    elseif action < 85 then
-        bar = 'pfActionBarStanceBar1'
-    elseif action < 97 then
-        bar = 'pfActionBarStanceBar2'
-    elseif action < 109 then
-        bar = 'pfActionBarStanceBar3'
-    elseif action < 121 then
-        bar = 'pfActionBarStanceBar4'
-    else
-        bar = 'pfActionBarMain'
+    for i = 1, table.getn(PF_BARS) do
+        local bar = PF_BARS[i]
+        local nextFirst = PF_BARS[i + 1] and PF_BARS[i + 1].first or 121
+        if action >= bar.first and action < nextFirst then
+            local index = action - bar.first + 1
+            return _G[bar.name .. "Button" .. index]
+        end
     end
-
-    local i = 1
-    if mod(action, 12) ~= 0 then
-        i = mod(action, 12)
-    else
-        i = 12
-    end
-
-    return _G[bar .. 'Button' .. i]
 end
 
 -- Dragonflight3

--- a/main.lua
+++ b/main.lua
@@ -176,6 +176,12 @@ local function FlyoutBarButton_OnEnter()
    Flyout_Show(this)
 end
 
+local function FlyoutBarButton_OnClick()
+   if arg1 ~= 'RightButton' then
+      Flyout_OnClick(this)
+   end
+end
+
 local function UpdateBarButton(slot)
    local button = Flyout_GetActionButton(slot)
    if button then
@@ -195,6 +201,12 @@ local function UpdateBarButton(slot)
             button.preFlyoutOnLeave = nil
          end
 
+         -- Restore original OnClick when this slot is no longer a flyout.
+         if button.preFlyoutOnClick ~= nil then
+            button:SetScript('OnClick', button.preFlyoutOnClick)
+            button.preFlyoutOnClick = nil
+         end
+
          flyouts[slot] = nil
          return
       end
@@ -209,6 +221,11 @@ local function UpdateBarButton(slot)
          if not button.preFlyoutOnEnter then
             button.preFlyoutOnEnter = button:GetScript('OnEnter')
             button.preFlyoutOnLeave = button:GetScript('OnLeave')
+         end
+
+         if button.preFlyoutOnClick == nil then
+            button.preFlyoutOnClick = button:GetScript('OnClick') or false
+            button:SetScript('OnClick', FlyoutBarButton_OnClick)
          end
 
          -- Identify sticky menus.


### PR DESCRIPTION
Hey!

I encountered an issue while using [me0wg4ming's fork of pfUI](https://github.com/me0wg4ming/pfUI).
The default action of a flyout macro would not be cast while using pfUI's actionbar.
The UseAction override never overwrote pfUI's own UseAction, so the default action was never cast. 
The original pfUI action bar compatibility was missing the paging bar, so I added it. The original mod() function also aliased the last slot of each bar to the wrong button, so I removed it.

I've tested it and it did not create any new issues, although I could've missed something.

Feel free to ask for more information or clarification or reject if this does not meet your standards.

Thanks for the very useful addon!