### PR TITLE
Added a modifier to allow flyout direction to be specified in the macro.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -140,6 +140,10 @@ local function GetFlyoutActionInfo(action)
 end
 
 local function GetFlyoutDirection(button)
+   if button.flyoutDirection then
+      return button.flyoutDirection
+   end
+
    local horizontal = false
    local bar = button:GetParent()
    if bar:GetWidth() > bar:GetHeight() then
@@ -212,6 +216,7 @@ local function UpdateBarButton(slot)
       end
 
       button.sticky = false
+      button.flyoutDirection = nil
 
       local icon = false
       local macro = GetActionText(slot)
@@ -238,6 +243,14 @@ local function UpdateBarButton(slot)
             icon = true
 
             body = strgsub(body, '%[icon%]', '')
+         end
+
+         -- Identify direction override.
+         local _, _, dirValue = strfind(body, '%[direction:(%a+)%]')
+         if dirValue then
+            body = strgsub(body, '%[direction:%a+%]', '')
+            local dirMap = { up = 'TOP', down = 'BOTTOM', left = 'LEFT', right = 'RIGHT' }
+            button.flyoutDirection = dirMap[strlower(dirValue)]
          end
 
          body = strsub(body, e + 1)


### PR DESCRIPTION
Added a [direction] modifier that takes a value such as [direction:up] or [direction:down] (also left and right) to override the default flyout direction when required.